### PR TITLE
Improve dependency entries

### DIFF
--- a/base/build.mjs
+++ b/base/build.mjs
@@ -2,7 +2,7 @@ import esbuild from 'esbuild'
 
 const commonConfig = {
   bundle: true,
-  external: ['bcrypt'],
+  external: ['bcrypt', 'jose'],
   format: 'esm',
   platform: 'node',
   target: 'esnext',

--- a/base/package.json
+++ b/base/package.json
@@ -28,11 +28,11 @@
     "eslint-config-base": "*",
     "mongodb-memory-server-core": "8.15.1",
     "typescript": "^5.0.4",
-    "vitest": "^0.34.4"
+    "vitest": "^0.34.4",
+    "radix3": "^1.0.1"
   },
   "dependencies": {
     "bcrypt": "^5.1.1",
-    "jose": "^5.1.0",
-    "radix3": "^1.0.1"
+    "jose": "^5.1.0"
   }
 }

--- a/create-mango/source/create-project.ts
+++ b/create-mango/source/create-project.ts
@@ -158,7 +158,6 @@ async function createProject(options: Options) {
 					'@mangobase/express',
 					'@mangobase/mongodb',
 					'@next/env',
-					'bcrypt',
 					'express',
 					'mangobase',
 					'mongodb',

--- a/express-server/build.mjs
+++ b/express-server/build.mjs
@@ -3,7 +3,7 @@ import esbuild from 'esbuild'
 esbuild.build({
   bundle: true,
   entryPoints: ['src/index.ts'],
-  external: ['express', 'mangobase'],
+  external: ['express', 'mangobase', 'cors'],
   format: 'esm',
   outdir: 'dist/',
   platform: 'node',


### PR DESCRIPTION
Since bundling will happen at the application level, we don't need to bundle other libraries with this library's code. Just specify them as dependencies.