### PR TITLE
fix: use JSON.stringify/parse to clone queries

### DIFF
--- a/base/src/lib/clone.ts
+++ b/base/src/lib/clone.ts
@@ -1,0 +1,5 @@
+function clone<T>(obj: T) {
+  return JSON.parse(JSON.stringify(obj)) as T
+}
+
+export { clone }

--- a/base/src/schema.test.ts
+++ b/base/src/schema.test.ts
@@ -861,9 +861,7 @@ describe('schema', () => {
       expect(
         schema.castQuery({ createdAt: { $gte: undefined } })
       ).toStrictEqual({
-        createdAt: {
-          $gte: undefined,
-        },
+        createdAt: {},
       })
 
       expect(schema.castQuery({ createdAt: { $gte: true } })).toStrictEqual({

--- a/base/src/schema.ts
+++ b/base/src/schema.ts
@@ -1,3 +1,5 @@
+import { clone } from './lib/clone.js'
+
 const types = [
   'any',
   'array',
@@ -157,7 +159,7 @@ class Schema {
    * With this knowledge, only nested query operators (eg. $in) are also considered.
    */
   castQuery(query: Record<string, any>) {
-    const res = structuredClone(query)
+    const res = clone(query)
 
     for (const [key, value] of Object.entries(res)) {
       const definition = this.getDefinitionAtPath(key)
@@ -259,7 +261,7 @@ class Schema {
       throw new Error('`data` is undefined')
     }
 
-    const res = structuredClone(data)
+    const res = clone(data)
 
     for (const [key, definition] of Object.entries(this.schema)) {
       const value = res[key]


### PR DESCRIPTION
Benchmark suggests it's faster.

```
┌─────────┬────────────────────────┬───────────┬────────────────────┬──────────┬─────────┐
│ (index) │       Task Name        │  ops/sec  │ Average Time (ns)  │  Margin  │ Samples │
├─────────┼────────────────────────┼───────────┼────────────────────┼──────────┼─────────┤
│    0    │   'structured clone'   │ '189,217' │ 5284.931509781234  │ '±0.28%' │  94609  │
│    1    │ 'json stringify/parse' │ '249,427' │ 4009.1878973210573 │ '±0.39%' │ 124714  │
└─────────┴────────────────────────┴───────────┴────────────────────┴──────────┴─────────┘

```

Also, applying `structuredClone` on `ObjectId`s converts it to `{}`